### PR TITLE
Add: workflow for branch protection rule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Branch Protection Check
+name: Branch Must Be Up To Date Check
 on:
   pull_request:
     branches: [main]  # adjust to your protected branch


### PR DESCRIPTION
added simple "dummy" check so that we can turn on "Require branches to be up to date before merging" setting which must be linked to a workflow check