### PR TITLE
add: test for each public method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,14 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Mockito for unit testing (mocking HttpServletRequest, etc.) -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.12.0</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- SLF4J -->
         <dependency> 
             <groupId>org.slf4j</groupId>

--- a/src/main/java/lab2/ContinuousIntegrationServer.java
+++ b/src/main/java/lab2/ContinuousIntegrationServer.java
@@ -48,7 +48,7 @@ public class ContinuousIntegrationServer extends AbstractHandler
     public String payloadToString(HttpServletRequest request){
         if (!"POST".equals(request.getMethod())) {
             System.out.println("Not a POST request, skipping JSON parsing");
-            return "";
+            return "NOT A POST REQUEST";
         }
 
         // Read the entire request body
@@ -211,6 +211,9 @@ public class ContinuousIntegrationServer extends AbstractHandler
 
             response.getWriter().println("CI job done"); //shown in the browser
             return;
+        }
+        else{
+            System.err.println("Not a POST request");
         }
 
         // Default response for non-POST, non-builds routes

--- a/src/test/java/lab2/ContinousIntegrationServerTest.java
+++ b/src/test/java/lab2/ContinousIntegrationServerTest.java
@@ -4,8 +4,19 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.Request;
+
+import static org.mockito.Mockito.*;
 
 public class ContinousIntegrationServerTest {
 
@@ -45,5 +56,37 @@ public class ContinousIntegrationServerTest {
         payloadString = "";
         Exception exception = assertThrows(Exception.class, () -> server.parseJSON(payloadString));
         assertEquals("No payload received", exception.getMessage());
+    }
+
+    @Test
+    /**
+     * Contract: For non-POST requests, payloadToString should skip parsing and return an explanatory string.
+     * Input: A mocked HttpServletRequest with method = "GET".
+     * Output: "NOT A POST REQUEST".
+     */
+    void testPayloadToStringNonPostReturnsMessage() {
+        ContinuousIntegrationServer server = new ContinuousIntegrationServer();
+
+        // Arrange: mock a non-POST request
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("GET");
+
+        String result = server.payloadToString(request);
+
+        assertEquals("NOT A POST REQUEST", result);
+    }
+    
+    @Test
+    /**
+     * Contract: The function should throw a NullPointerException if the request is null.
+     * Input: Null request.
+     * Output: NullPointerException thrown.
+     */
+    void testHandleWithNullRequestThrows() {
+        ContinuousIntegrationServer server = new ContinuousIntegrationServer();
+
+        assertThrows(NullPointerException.class, () -> 
+            server.handle("/", null, null, null)
+        );
     }
 }


### PR DESCRIPTION
Add or extend tests for parseJSON, payloadToString, and handle (including error and invalid-input paths) using Mockito where possible.
- added mockito to pom.xml

closes #45 